### PR TITLE
fix: Preserve element order and whitespace when accepting tracked cha…

### DIFF
--- a/src/xml/XMLParser.ts
+++ b/src/xml/XMLParser.ts
@@ -565,7 +565,9 @@ export class XMLParser {
       if (nextTag === -1) {
         // No more tags - rest is text
         const text = content.substring(pos);
-        if (text.trim()) {
+        // When trimValues is false, preserve whitespace-only text
+        // When trimValues is true, only include text that has non-whitespace content
+        if (text.length > 0 && (!options.trimValues || text.trim())) {
           // Unescape XML entities in text content (e.g., &lt; -> <)
           textContent += XMLBuilder.unescapeXml(text);
         }
@@ -575,7 +577,9 @@ export class XMLParser {
       // Collect text before next tag
       if (nextTag > pos) {
         const text = content.substring(pos, nextTag);
-        if (text.trim()) {
+        // When trimValues is false, preserve whitespace-only text
+        // When trimValues is true, only include text that has non-whitespace content
+        if (text.length > 0 && (!options.trimValues || text.trim())) {
           // Unescape XML entities in text content (e.g., &lt; -> <)
           textContent += XMLBuilder.unescapeXml(text);
         }
@@ -612,7 +616,9 @@ export class XMLParser {
     }
 
     // Add text content
-    if (textContent.trim()) {
+    // When trimValues is false, include whitespace-only text
+    // When trimValues is true, only include text with non-whitespace content
+    if (textContent.length > 0 && (!options.trimValues || textContent.trim())) {
       const text = options.trimValues ? textContent.trim() : textContent;
       if (typeof elementValue === "object" && !Array.isArray(elementValue)) {
         if (Object.keys(elementValue).length === 0) {


### PR DESCRIPTION
…nges

- Fix RevisionWalker.unwrapAllElements to maintain correct element order when unwrapping revision elements (e.g., table rows inside w:ins)
- Fix XMLParser to preserve whitespace-only text content when trimValues is false (e.g., spaces in tracked changes like <w:t xml:space="preserve"> </w:t>)

These fixes resolve issues where:
1. Table rows wrapped in tracked changes appeared in wrong order after acceptance
2. Spaces were lost when accepting formatting changes (e.g., "Parent Document:CALL-0011" instead of "Parent Document: CALL-0011")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maintains correct element order when unwrapping revision nodes and preserves whitespace-only text in XML parsing when trimValues is false.
> 
> - **Revisions (RevisionWalker)**:
>   - Rewrite `unwrapAllElements` to derive ordered children from parent `_orderedChildren`, extract children from revision nodes accordingly, and rebuild parent element arrays and `_orderedChildren` in correct order.
>   - Add fallback merge path when no `_orderedChildren` exists; remove `updateOrderedChildrenForUnwrap`.
> - **XML Parsing (XMLParser)**:
>   - Preserve whitespace-only text when `trimValues` is false for text before/after child tags and for element text content aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1adeb37a34437dbda2d9ff91fb577d1c2d38fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->