### PR TITLE
Fixed Bold preservation

### DIFF
--- a/src/xml/XMLParser.ts
+++ b/src/xml/XMLParser.ts
@@ -789,7 +789,15 @@ export class XMLParser {
           charAfter === "\n" ||
           charAfter === "\r"
         ) {
-          // This is a real opening tag
+          // This looks like a real opening tag - but check if it's self-closing
+          // Self-closing tags like <w:rPr/> should NOT increase depth
+          const tagEnd = xml.indexOf(">", candidateOpen);
+          if (tagEnd !== -1 && xml[tagEnd - 1] === "/") {
+            // Self-closing tag - skip it (don't affect depth)
+            searchPos = tagEnd + 1;
+            continue;
+          }
+          // This is a real opening tag (not self-closing)
           realOpenPos = candidateOpen;
           break;
         }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust `findClosingTag` to skip self-closing tags when counting depth, fixing mis-parsing of nested same-name elements; add regression test.
> 
> - **XML Parsing**:
>   - Update `findClosingTag` in `src/xml/XMLParser.ts` to treat self-closing tags as non-nesting, preventing incorrect depth increments for nested same-name elements.
> - **Tests**:
>   - Add regression test in `tests/xml/XMLParser-parseToObject.test.ts` ensuring nested self-closing tags within `w:rPrChange` are parsed without promoting siblings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 127438265775ae3a44d2b69ce18df08aa8bcd9b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->