### PR TITLE
Multi-Paragraph Parsing Implementation

### DIFF
--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -106,6 +106,7 @@ Converts XML from DOCX files into JavaScript object models.
 - **Hyperlink Defragmentation**: Merges consecutive hyperlinks with same URL
 - **Special Characters**: Converts `<w:tab/>`, `<w:br/>` to string equivalents
 - **Complex Fields**: Parses field instructions and content
+- **Multi-Paragraph Complex Fields**: Assembles fields (like TOC) that span multiple paragraphs into single `ComplexField` objects marked with `isMultiParagraph()`. Field tokens are removed from subsequent paragraphs after assembly.
 - **Content Controls**: Handles SDT (Structured Document Tags)
 - **Element Order Preservation**: Uses `_orderedChildren` from XMLParser for correct tab/break ordering
 - **Nested Element Handling**: Skips past closing tags when scanning to avoid counting nested runs


### PR DESCRIPTION
Changes Made
Added assembleMultiParagraphFields() method (src/core/DocumentParser.ts:1559-1680)

Scans all paragraphs (including those in tables and SDTs) for field markers
Tracks field state (begin/separate/end) across paragraphs
When a field spans multiple paragraphs, collects all related runs
Creates a ComplexField marked as multiParagraph: true
Places the ComplexField in the first paragraph and removes field tokens from subsequent paragraphs
For single-paragraph fields, delegates to existing assembleComplexFields()
Added collectAllParagraphs() helper method (src/core/DocumentParser.ts:1682-1710)

Extracts paragraphs from body elements, tables, and SDTs
Added processMultiParagraphField() method (src/core/DocumentParser.ts:1712-1783)

Processes a single multi-paragraph field tracker
Groups runs by paragraph index
Updates first paragraph to contain the assembled ComplexField
Removes field tokens from subsequent paragraphs
Updated parseBodyElements() (src/core/DocumentParser.ts:299-300)

Calls assembleMultiParagraphFields() after all paragraphs are parsed
Removed the TODO comment (src/core/DocumentParser.ts:541-544)

Replaced with a note explaining that complex field assembly now happens at the parseBodyElements level
Updated documentation (src/core/CLAUDE.md:109)

Added documentation for multi-paragraph complex field handling